### PR TITLE
chore: remove the comma

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -9,7 +9,7 @@
 
   "vars": {
     /* Note: Configure this to be an email from a domain where you have Email Routing enabled */
-    "EMAIL_FROM": "PLEASE CONFIGURE ME",
+    "EMAIL_FROM": "PLEASE CONFIGURE ME"
   },
 
   /* Note: comment this out if you haven't set up Email Routing */


### PR DESCRIPTION
The comma causes a Wrangler error.

![CleanShot 2024-12-08 at 14 58 13@2x](https://github.com/user-attachments/assets/b1d95f06-712e-4732-9f36-55cb29a23220)
