### PR TITLE
fix: remove `entrypoint_name` from from `local-proxy.ts`

### DIFF
--- a/scripts/local-proxy.ts
+++ b/scripts/local-proxy.ts
@@ -21,11 +21,11 @@ export function log(...args: any[]) {
   process.stderr.write(msg)
 }
 
-const [_, __, claude_name, workers_url, entrypoint_name, ...rest] = process.argv
-log(claude_name, workers_url, entrypoint_name)
+const [_, __, claude_name, workers_url, ...rest] = process.argv
+log(claude_name, workers_url)
 
-if (!claude_name || !workers_url || !entrypoint_name || rest.length > 0) {
-  console.error('usage: tsx ./scripts/local-proxy.ts <claude_name> <workers_url> <entrypoint_name>')
+if (!claude_name || !workers_url || rest.length > 0) {
+  console.error('usage: tsx ./scripts/local-proxy.ts <claude_name> <workers_url>')
   process.exit(1)
 }
 
@@ -117,7 +117,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   if (!method) {
     return {
-      content: [{ type: 'text', text: `Couldn't find method '${toolName}' in entrypoint ${entrypoint_name}` }],
+      content: [{ type: 'text', text: `Couldn't find method '${toolName}' in entrypoint` }],
       isError: true,
     }
   }
@@ -131,7 +131,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       'Content-Type': 'application/json',
       Authorization: 'Bearer ' + SHARED_SECRET,
     },
-    body: JSON.stringify({ entrypoint: entrypoint_name, method: toolName, args }),
+    body: JSON.stringify({ method: toolName, args }),
   }
   log(JSON.stringify(init))
   const response = await fetch(workers_url + '/rpc', init)


### PR DESCRIPTION
With the current code, it does not work on my Claude desktop because there is a difference between the the arguments written in `claude_desktop_config.json` and `local-proxy.ts`:

`claude_desktop_config.json` is `<claude_name> <workers_url>`:

```json
{
  "mcpServers": {
    "workers-mcp-server": {
      "command": "/usr/local/bin/node",
      "args": [
        "/Users/yusuke/work/workers-mcp-server/node_modules/tsx/dist/cli.mjs",
        "/Users/yusuke/work/workers-mcp-server/scripts/local-proxy.ts",
        "workers-mcp-server",
        "https://workers-mcp-server.yusukebe.workers.dev"
      ]
    }
  }
}
```

`local-proxy.ts` is `<claude_name> <workers_url> <entrypoint_name>`:

https://github.com/geelen/workers-mcp-server/blob/b022c21d564d4513a51c6dcb8979efa917943892/scripts/local-proxy.ts#L27-L30

I'm not sure this PR approach is good for you, but I think the `entrypoint_name` is not necessary in `local-proxy.ts` since the `/rpc` endpoint will not use it. So, I've removed all `entrypoint_name` items from `local-proxy.ts`, and it works well on my Claude desktop!